### PR TITLE
included and changed execution order to speed up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # Dockerfile for distributed execution using PHT
 FROM rocker/r-ver:latest
-MAINTAINER kais.tahar@med.uni-goettingen.de
-
+#MAINTAINER kais.tahar@med.uni-goettingen.de (deprecated)
+LABEL Maintainer="kais.tahar@med.uni-goettingen.de" 
+LABEL Description="CORD Dataquality checker"
 # Label
 LABEL envs="[{\"name\":\"FHIR_SERVER\",\"type\":\"string\",\"required\":true},{\"name\":\"INPATIENT_CASE_NO\",\"type\":\"string\",\"required\":true}]"
 
 WORKDIR /usr/local/src/myScripts
-
-# copy files
-COPY . .
 
 # install packages
 RUN apt-get update -qq && apt-get install -y libxml2-dev libcurl4-openssl-dev libssl-dev
@@ -17,8 +15,11 @@ RUN R -e "install.packages('fhircrackr')"
 RUN R -e "install.packages('openxlsx')"
 Run R -e "devtools::install_github('https://github.com/KaisTahar/dqLib')"
 
+# copy files
+COPY . .
+
 # run R script
 WORKDIR ./PHT
 RUN pwd && ls
-CMD Rscript ./cordDqChecker_PHT.R
+CMD ["Rscript","./cordDqChecker_PHT.R"]
 


### PR DESCRIPTION
Hello creator,
i have included Label instead of Maintainer because Maintainer is deprecated according the docker in the following link 
https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile. 
Then i have changed the order in which the execution takes place. That is run the installation and packages first and then successively execute the copy step to speed up the process. This will help when the script is revised for changes  the build process will be quicker compared to your previous build.
