### PR TITLE
xlsx file extension excluded 

### DIFF
--- a/Local/R/dqFhirInterface.R
+++ b/Local/R/dqFhirInterface.R
@@ -118,7 +118,8 @@ names(condAlphaID) <- c("PatientIdentifikator","Aufnahmenummer", "Diagnosetext",
 
 # join condition data
 conditions <-Reduce(function(x, y) merge(x, y, all=T), list(condIcd,condOrpha, condAlphaID))
-
+# if you have more than one merge package installed then comment the above line and uncomment the below line
+#conditions <-Reduce(function(x, y) base::merge(x, y, all=T), list(condIcd,condOrpha, condAlphaID))
 # convert and save fhir bundles to a data frame patRaw
 patRaw <- fhir_crack(bundles, design)$PatientTab
 patients <- fhir_rm_indices(patRaw, brackets = c("[", "]"))
@@ -133,5 +134,6 @@ encounters$start <- as.Date(encounters$start)
 encounters$end <- as.Date(encounters$end)
 names(encounters) <- c("PatientIdentifikator","Aufnahmenummer","Aufnahmedatum", "Entlassungsdatum", "Kontakt-Klasse", "Fall-Status", "Aufnahmeanlass", "DiagnoseRolle")
 instData<-Reduce(function(x, y) merge(x, y, all=T), list(patients,encounters,conditions))
-
+# if you have more than one merge package installed then comment the above line and uncomment the below line
+#instData<-Reduce(function(x, y) base::merge(x, y, all=T), list(patients,encounters,conditions))
 

--- a/Local/cordDqChecker.R
+++ b/Local/cordDqChecker.R
@@ -7,6 +7,7 @@ rm(list = ls())
 setwd("./")
 # installall required packages
 #source("./R/installPackages.R")
+source(paste(getwd(),"/Local/R/installPackages.R",sep=""), force=TRUE)
 library(dqLib)
 library(openxlsx)
 #library(writexl)
@@ -63,8 +64,10 @@ repCol=c( "PatientIdentifikator", "Aufnahmenummer", "ICD_Primaerkode","Orpha_Kod
 #------------------------------------------------------------------------------------------------------
 # Import ref. Data
 #------------------------------------------------------------------------------------------------------
-refData1 <- read.table("./Data/refData/cordDqList.csv", sep=",",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
-refData2 <- read.table("./Data/refData/icd10gm2020_alphaid_se_muster_edvtxt_20191004.txt", sep="|",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
+refData1 <- read.table("./Local/Data/refData/cordDqList.csv", sep=",",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
+#refData1 <- read.table(paste(getwd(),"/Local/Data/refData/cordDqList.csv",sep=""), sep=",",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
+refData2 <- read.table("./Local/Data/refData/icd10gm2020_alphaid_se_muster_edvtxt_20191004.txt", sep="|",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
+#refData2 <- read.table(paste(getwd(),"/Local/Data/refData/icd10gm2020_alphaid_se_muster_edvtxt_20191004.txt",sep=""), sep="|",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
 headerRef1<- c ("IcdCode", "OrphaCode", "Type")
 headerRef2<- c ("Gueltigkeit", "Alpha_ID", "ICD_Primaerkode1", "ICD_Manifestation", "ICD_Zusatz","ICD_Primaerkode2", "Orpha_Kode", "Label")
 names(refData1)<-headerRef1
@@ -77,7 +80,8 @@ medData <- NULL
 if (is.null(path) | path=="")  stop("No path to data") else {
   if (grepl("fhir", path))
   {
-    source("./R/dqFhirInterface.R")
+    #source("./R/dqFhirInterface.R")
+    source(paste(getwd(),"/Local/R/dqFhirInterface.R",sep=""))
     medData<- instData[ format(as.Date(instData$Entlassungsdatum, format="%Y-%m-%d"),"%Y")==reportYear, ]
   }else{ ext <-getFileExtension (path)
   if (ext=="csv") medData <- read.table(path, sep=";", dec=",",  header=T, na.strings=c("","NA"), encoding = "latin1")
@@ -141,14 +145,17 @@ if (!is.empty(medData$Institut_ID)){
     )
     dqRepCol <- c(repMeta, compInd, plausInd, uniqInd, concInd, dqKeyNo)
     # DQ report
-    out <-checkCordDQ(instID, reportYear, inpatientCases, refData1, refData2, dqRepCol, "dq_msg", "basicItem", "Total", oItem)
-    dqRep <-out$metric
-    mItem <-out$mItem
+    #out <-checkCordDQ(instID, reportYear, inpatientCases, refData1, refData2, dqRepCol, "dq_msg", "basicItem", "Total", oItem)
+    dqRep <-checkCordDQ(instID, reportYear, inpatientCases, refData1, refData2, dqRepCol, "dq_msg", "basicItem", "Total", oItem)
+    #dqRep <-out$metric# retaining dqRep variable for data quality check 
+    #mItem <-out$mItem # retaining dqRep variable for data quality check 
     
   }
   
   ################################################### DQ Reports ########################################################
-  path<- paste ("./Data/Export/", exportFile, "_", dqRep$report_year,  sep = "")
+  #path<- paste ("./Data/Export/", exportFile, "_", dqRep$report_year,  sep = "")
+  path<- paste(getwd(),"/Local/Data/Export/", exportFile, "_", dqRep$report_year,  sep = "")
+  path <- paste(path,".xlsx",sep = "")
   getReport( repCol, "dq_msg", dqRep, path)
   top <- paste ("\n \n ####################################***CordDqChecker***###########################################")
   msg <- paste ("\n Data quality analysis for location:", dqRep$inst_id,

--- a/Local/cordDqChecker.R
+++ b/Local/cordDqChecker.R
@@ -7,7 +7,7 @@ rm(list = ls())
 setwd("./")
 # installall required packages
 #source("./R/installPackages.R")
-source(paste(getwd(),"/Local/R/installPackages.R",sep=""), force=TRUE)
+#source(paste(getwd(),"/Local/R/installPackages.R",sep=""), force=TRUE)
 library(dqLib)
 library(openxlsx)
 #library(writexl)

--- a/Local/cordDqChecker.R
+++ b/Local/cordDqChecker.R
@@ -151,7 +151,6 @@ if (!is.empty(medData$Institut_ID)){
   
   ################################################### DQ Reports ########################################################
   path<- paste ("./Local/Data/Export/", exportFile, "_", dqRep$report_year,  sep = "")
-  path <- paste(path,".xlsx",sep = "")# file extension included
   getReport( repCol, "dq_msg", dqRep, path)
   top <- paste ("\n \n ####################################***CordDqChecker***###########################################")
   msg <- paste ("\n Data quality analysis for location:", dqRep$inst_id,

--- a/Local/cordDqChecker.R
+++ b/Local/cordDqChecker.R
@@ -6,7 +6,7 @@
 rm(list = ls())
 setwd("./")
 # installall required packages
-#source("./R/installPackages.R")
+#source("./Local/R/installPackages.R")
 #source(paste(getwd(),"/Local/R/installPackages.R",sep=""), force=TRUE)
 library(dqLib)
 library(openxlsx)
@@ -65,9 +65,7 @@ repCol=c( "PatientIdentifikator", "Aufnahmenummer", "ICD_Primaerkode","Orpha_Kod
 # Import ref. Data
 #------------------------------------------------------------------------------------------------------
 refData1 <- read.table("./Local/Data/refData/cordDqList.csv", sep=",",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
-#refData1 <- read.table(paste(getwd(),"/Local/Data/refData/cordDqList.csv",sep=""), sep=",",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
 refData2 <- read.table("./Local/Data/refData/icd10gm2020_alphaid_se_muster_edvtxt_20191004.txt", sep="|",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
-#refData2 <- read.table(paste(getwd(),"/Local/Data/refData/icd10gm2020_alphaid_se_muster_edvtxt_20191004.txt",sep=""), sep="|",  dec=",", na.strings=c("","NA"), encoding = "UTF-8")
 headerRef1<- c ("IcdCode", "OrphaCode", "Type")
 headerRef2<- c ("Gueltigkeit", "Alpha_ID", "ICD_Primaerkode1", "ICD_Manifestation", "ICD_Zusatz","ICD_Primaerkode2", "Orpha_Kode", "Label")
 names(refData1)<-headerRef1
@@ -80,8 +78,7 @@ medData <- NULL
 if (is.null(path) | path=="")  stop("No path to data") else {
   if (grepl("fhir", path))
   {
-    #source("./R/dqFhirInterface.R")
-    source(paste(getwd(),"/Local/R/dqFhirInterface.R",sep=""))
+    source("./Local/R/dqFhirInterface.R")
     medData<- instData[ format(as.Date(instData$Entlassungsdatum, format="%Y-%m-%d"),"%Y")==reportYear, ]
   }else{ ext <-getFileExtension (path)
   if (ext=="csv") medData <- read.table(path, sep=";", dec=",",  header=T, na.strings=c("","NA"), encoding = "latin1")
@@ -153,9 +150,8 @@ if (!is.empty(medData$Institut_ID)){
   }
   
   ################################################### DQ Reports ########################################################
-  #path<- paste ("./Data/Export/", exportFile, "_", dqRep$report_year,  sep = "")
-  path<- paste(getwd(),"/Local/Data/Export/", exportFile, "_", dqRep$report_year,  sep = "")
-  path <- paste(path,".xlsx",sep = "")
+  path<- paste ("./Local/Data/Export/", exportFile, "_", dqRep$report_year,  sep = "")
+  path <- paste(path,".xlsx",sep = "")# file extension included
   getReport( repCol, "dq_msg", dqRep, path)
   top <- paste ("\n \n ####################################***CordDqChecker***###########################################")
   msg <- paste ("\n Data quality analysis for location:", dqRep$inst_id,


### PR DESCRIPTION
Hi, 
I tested cordDQChecker.R and included /Local/ to Path. 'out' variable did not contain metric and mItem so i retained 'dqRep' as the output to checkCordDQ. 'dqRep' was already added to getReport step. Excluded .xlsx in file extension from my previous pull request because it was needed. The file type was already defined 

Best regards
RM